### PR TITLE
issue/55 - handle certain errors as unreachable errors

### DIFF
--- a/ansibledriver/config/ald_config.yml
+++ b/ansibledriver/config/ald_config.yml
@@ -7,7 +7,7 @@ application:
 
 ansible:
   unreachable_sleep_seconds: 5
-  max_unreachable_retries: 1000
+  max_unreachable_retries: 60
   output_prop_prefix: 'output__'
 
 process:


### PR DESCRIPTION
module error host is unreachable the same as a regular unreachable error. Reduce the default timeout for retry attempts. Factor in the time it takes to make the attempt.

Closes #55 